### PR TITLE
Fix multiplication identity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ where
     (T, Succ<U>): Mul,
     (Succ<U>, <(T, Succ<U>) as Mul>::Product): Add,
 {
-    // x * y = x + (x - 1) * y
+    // x * y = y + (x - 1) * y
     type Product = <(Succ<U>, <(T, Succ<U>) as Mul>::Product) as Add>::Sum;
 }
 


### PR DESCRIPTION
Hi!

I think that it should be `y` instead of `x` there, which can be confirmed by distributing `(x - 1) * y`

Note that it's also incorrect in two places in the [blog post](https://fprasx.github.io/articles/type-system-arithmetic/), including:

```rust
Succ<U>,                       // x
```

As `Succ<U>` is y!