### PR TITLE
Don't use PhantomData

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "12345678"]
-use std::marker::PhantomData;
 
 fn main() {
     println!(
@@ -37,7 +36,7 @@ macro_rules! encode {
 struct Zero;
 
 #[derive(Debug)]
-struct Succ<T>(PhantomData<T>);
+struct Succ<T>(T);
 
 // Evaluation
 


### PR DESCRIPTION
AFAICT, this has no effect here, or does it?

All involved types are zero-size anyway.